### PR TITLE
Added Markdown Alerts

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -155,6 +155,30 @@
     "prefix": "md-comment",
     "body": ["<!--- ${1:comment} ---> ${0}"],
     "description": "Markdown Comment"
+  },
+  "Note": {
+    "prefix": "md-note",
+    "body": ["> [!NOTE]\n> ${0}"],
+    "description": "Markdown Note"
+  },
+  "Tip": {
+    "prefix": "md-tip",
+    "body": ["> [!TIP]\n> ${0}"],
+    "description": "Markdown Tip"
+  },
+  "Important": {
+    "prefix": "md-important",
+    "body": ["> [!IMPORTANT]\n> ${0}"],
+    "description": "Markdown Important"
+  },
+  "Warning": {
+    "prefix": "md-warning",
+    "body": ["> [!WARNING]\n> ${0}"],
+    "description": "Markdown Warning"
+  },
+  "Caution": {
+    "prefix": "md-caution",
+    "body": ["> [!CAUTION]\n> ${0}"],
+    "description": "Markdown Caution"
   }
 }
-


### PR DESCRIPTION
Hey, I have been using this extension for a long time now and have been using this patch locally. I thought it would be grateful to add this feature into the main branch.

Here's the article explaining how it renders in the webpage,  
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts