### PR TITLE
Removed extra whitespace

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -184,7 +184,7 @@
   "Page Break": {
     "prefix": "md-page-break",
     "body": [
-      "<div style=\"page-break-after: always;\"></div>\n $0"],
+      "<div style=\"page-break-after: always;\"></div>\n$0"],
     "description": "Markdown Page Break"
   },
 }


### PR DESCRIPTION
Hey nice to see that you are updating the repo. I have noticed that there's a small whitespace present in the latest **page break** snippet as shown in the image below, 
![image](https://github.com/Amereyeu/Markdown-snippets/assets/70560640/0506dfdf-27e1-478c-8fc9-a905ec046e28)

I have found that this is caused by the little space in line 187 of [this commit](https://github.com/Amereyeu/Markdown-snippets/commit/2a957a1b516308c2c3abea41240667a3aea6b747).
![image](https://github.com/Amereyeu/Markdown-snippets/assets/70560640/d4db3e7b-4f14-4dd5-94fc-eb96fc374576)

I have fixed it by removing that space so that users (i wonder how many still use this lol) won't have to press the backspace just to maintain code styling. I know this is a small commit but I hope it's honest work and would make this extension better. 